### PR TITLE
Add granite to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: David Hewitt <davidmhewitt@gmail.com>
 Build-Depends: debhelper (>= 10.5.1),
                desktop-file-utils,
                libgeoclue-2-dev,
+               libgranite-dev,
                libgtk-3-dev,
                meson,
                valac (>= 0.34.1)


### PR DESCRIPTION
Follow-up to fadbea5.

This fixes the recent builds for the daily ppa failing: https://code.launchpad.net/~elementary-os/+recipe/pantheon-agent-geoclue2-daily

```
.
.
.
Run-time dependency granite found: NO (tried pkgconfig)

../meson.build:14:0: ERROR: Dependency "granite" not found, tried pkgconfig
dh_auto_configure: error: cd obj-x86_64-linux-gnu && LC_ALL=C.UTF-8 meson .. --wrap-mode=nodownload --buildtype=plain --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu --libexecdir=lib/x86_64-linux-gnu returned exit code 1
make: *** [debian/rules:13: build] Error 25
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
--------------------------------------------------------------------------------
Build finished at 2022-08-20T10:34:02Z

Finished
--------
```
